### PR TITLE
fix(deps): update accord to version 0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Chris Cowan",
   "license": "MIT",
   "dependencies": {
-    "accord": "^0.27.3",
+    "accord": "^0.28.0",
     "less": "2.6.x || ^2.7.1",
     "object-assign": "^4.0.1",
     "plugin-error": "^0.1.2",


### PR DESCRIPTION
accord@0.28 fixes its engine resolution algorithm.
It does not preserve symlinks anymore.
It is the wanted behavior because it is the way Node resolves
modules by default.

ref https://github.com/pnpm/pnpm/issues/118